### PR TITLE
Initialized palettes and themes for light and dark modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "main": "./dist/ui-kit-2022.umd.cjs",
   "module": "./dist/ui-kit-2022.js",
   "exports": {
@@ -26,9 +28,6 @@
     "build-storybook": "build-storybook",
     "build-gh-pages": "BASE_PATH=/ui-kit-2022/ npm run build-storybook",
     "prepare": "husky install"
-  },
-  "dependencies": {
-    
   },
   "peerDependencies": {
     "@mui/icons-material": "^5.10.6",

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,12 @@
+import { createTheme } from '@mui/material/styles';
+import * as palette from './palette';
+
+// See: https://mui.com/material-ui/customization/default-theme/
+
+export const light = createTheme({
+  palette: palette.light
+});
+
+export const dark = createTheme({
+  palette: palette.dark
+});

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -1,0 +1,25 @@
+/*
+ * Palette definitions for light and dark themes.
+ * Material UI theme schema reference: https://mui.com/material-ui/customization/default-theme/
+ */
+
+import { PaletteOptions } from '@mui/material';
+
+// Palette and PalleteOptions types can be extended here as needed 
+declare module '@mui/material/styles/createPalette' {
+  interface Palette {
+  }
+
+  interface PaletteOptions {
+  }
+}
+
+// TODO: Define MUI palettes for light theme
+export const light: PaletteOptions = {
+  mode: 'light',
+};
+
+// TODO: Define MUI palettes for dark theme
+export const dark: PaletteOptions = {
+  mode: 'dark',
+};


### PR DESCRIPTION
For now I've simply included a file that contains the color hex codes.

TODO: I've started integrating them into two MUI compatible themes: a light and a dark theme. I need to figure out how to map the design system colors to MUI's theme palette properties for each theme type (light and dark), particularly the Core-Primary and Core-Secondary colors. MUI has three properties for the "primary" and "secondary" palette colors: "light", "dark", and "main". The "light" and "dark" here are not the same as the theme mode (light mode or dark mode), they are a light and dark variant of the "main" color. So there will have to be a set of "light, "dark", and "main" for each theme color type (primary, secondary, error, etc.) for each theme (light/dark). Some colors might be in both themes, under a different "light", "dark", or "main" property depending on if the theme is light or dark. The challenge is to figure out which color can be assigned to where in both the light and dark themes.

MUI uses the properties defined here: https://mui.com/material-ui/customization/default-theme/. The theme JSON contains more than just colors, so there are many properties that can be shared between each.

Closes #20 