### PR TITLE
GH action workflow for NPM publish on release

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,19 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build 
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Build Storybook
         run: |
-          npm install
+          npm ci
           npm run build-gh-pages
 
       - name: Build Pages Artifact

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+storybook-static
 dist-ssr
 *.local
 


### PR DESCRIPTION
Before this is merged, the NPM_TOKEN needs to be added to Github's managed secrets for this project.

Closes #36 